### PR TITLE
feat: add `onSanitize` and `dryRun` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,36 @@ app.use(mongoSanitize());
 // Or, to replace prohibited characters with _, use:
 app.use(mongoSanitize({
   replaceWith: '_'
-}))
+}));
 
 ```
+
+### `onSanitize`
+
+`onSanitize` callback is called after the request's value was sanitized.
+
+```js
+app.use(mongoSanitize({
+  onSanitize: ({ req, key }) => {
+    console.warn(`This request[${key}] is sanitized`, req);
+  }
+}));
+```
+
+### `dryRun`
+
+You can run this middleware as dry run mode.
+
+```js
+app.use(mongoSanitize({
+  dryRun: true,
+  onSanitize: ({ req, key }) => {
+    console.warn(`[DryRun] This request[${key}] will be sanitized`, req);
+  }
+}));
+```
+
+### Node Modules API
 
 You can also bypass the middleware and use the module directly:
 

--- a/index.js
+++ b/index.js
@@ -93,8 +93,7 @@ function sanitize(target, options) {
  * @param {{replaceWith?: string, onSanitize?: function, dryRun?: boolean}} options
  * @returns {function}
  */
-function middleware(options) {
-  options = options || {};
+function middleware(options = {}) {
   const hasOnSanitize = typeof options.onSanitize === "function";
   return function(req, res, next) {
     ['body', 'params', 'headers', 'query'].forEach(function(key) {


### PR DESCRIPTION
- Add `onSanitize` option
- Add `dryRun` option

The `onSanitize` callback will be called even if the `dryRun` is `true`.
It aims to remove a built-in warning like https://github.com/fiznool/express-mongo-sanitize/issues/35#issuecomment-758908153 from this module

fix #35 