### PR TITLE
feat: Adding new options (options.allowDots) - OLD

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,8 +51,10 @@ function sanitize(target, options, regex) {
   if (!regex) {
     regex = TEST_REGEX;
 
-    if (options?.allowDots) {
-      TEST_REGEX = TEST_REGEX_WITHOUT_DOT;
+    if (options) {
+      if (options.allowDots) {
+        TEST_REGEX = TEST_REGEX_WITHOUT_DOT;
+      }
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -101,7 +101,11 @@ function middleware(options) {
         req[k] = sanitize(
           req[k],
           options,
-          options?.allowDots ? TEST_REGEX_WITHOUT_DOT : TEST_REGEX
+          options
+            ? options.allowDots
+              ? TEST_REGEX_WITHOUT_DOT
+              : TEST_REGEX
+            : null
         );
       }
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "express-mongo-sanitize",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test.js
+++ b/test.js
@@ -6,44 +6,48 @@ const bodyParser = require('body-parser');
 const expect = require('chai').expect;
 const sanitize = require('./index.js');
 
-describe('Express Mongo Sanitize', function() {
-  describe('Remove Data', function() {
+describe('Express Mongo Sanitize', function () {
+  describe('Remove Data', function () {
     const app = express();
-    app.use(bodyParser.urlencoded({extended: true}));
+    app.use(bodyParser.urlencoded({ extended: true }));
     app.use(bodyParser.json());
     app.use(sanitize());
 
-    app.post('/body', function(req, res){
+    app.post('/body', function (req, res) {
       res.status(200).json({
         body: req.body,
       });
     });
 
-    app.post('/headers', function (req, res){
+    app.post('/headers', function (req, res) {
       res.status(200).json({
-        headers: req.headers
+        headers: req.headers,
       });
     });
 
-    app.get('/query', function(req, res){
+    app.get('/query', function (req, res) {
       res.status(200).json({
-        query: req.query
+        query: req.query,
       });
     });
 
-    describe('Top-level object', function() {
-      it('should sanitize the query string', function(done) {
+    describe('Top-level object', function () {
+      it('should sanitize the query string', function (done) {
         request(app)
           .get('/query?q=search&$where=malicious&dotted.data=some_data')
           .set('Accept', 'application/json')
-          .expect(200, {
-            query: {
-              q: 'search'
-            }
-          }, done);
+          .expect(
+            200,
+            {
+              query: {
+                q: 'search',
+              },
+            },
+            done
+          );
       });
 
-      it('should sanitize a JSON body', function(done) {
+      it('should sanitize a JSON body', function (done) {
         request(app)
           .post('/body')
           .send({
@@ -53,21 +57,25 @@ describe('Express Mongo Sanitize', function() {
             even: null,
             stop: undefined,
             $where: 'malicious',
-            'dotted.data': 'some_data'
+            'dotted.data': 'some_data',
           })
           .set('Content-Type', 'application/json')
           .set('Accept', 'application/json')
-          .expect(200, {
-            body: {
-              q: 'search',
-              is: true,
-              and: 1,
-              even: null
-            }
-          }, done);
+          .expect(
+            200,
+            {
+              body: {
+                q: 'search',
+                is: true,
+                and: 1,
+                even: null,
+              },
+            },
+            done
+          );
       });
 
-      it('should sanitize HTTP headers', function(done) {
+      it('should sanitize HTTP headers', function (done) {
         request(app)
           .post('/headers')
           .set({
@@ -76,164 +84,200 @@ describe('Express Mongo Sanitize', function() {
             and: 1,
             even: null,
             $where: 'malicious',
-            'dotted.data': 'some_data'
+            'dotted.data': 'some_data',
           })
           .expect(200)
-          .expect(function(res) {
+          .expect(function (res) {
             expect(res.body.headers).to.include({
               q: 'search',
               is: 'true',
               and: '1',
-              even: 'null'
-            })
+              even: 'null',
+            });
           })
           .end(done);
       });
 
-      it('should sanitize a form url-encoded body', function(done) {
+      it('should sanitize a form url-encoded body', function (done) {
         request(app)
           .post('/body')
           .send('q=search&$where=malicious&dotted.data=some_data')
           .set('Content-Type', 'application/x-www-form-urlencoded')
           .set('Accept', 'application/json')
-          .expect(200, {
-            body: {
-              q: 'search'
-            }
-          }, done);
+          .expect(
+            200,
+            {
+              body: {
+                q: 'search',
+              },
+            },
+            done
+          );
       });
     });
 
-    describe('Nested Object', function() {
-      it('should sanitize a nested object in the query string', function(done) {
+    describe('Nested Object', function () {
+      it('should sanitize a nested object in the query string', function (done) {
         request(app)
           .get('/query?username[$gt]=foo&username[dotted.data]=some_data')
           .set('Accept', 'application/json')
-          .expect(200, {
-            query: {
-              username: {}
-            }
-          }, done);
+          .expect(
+            200,
+            {
+              query: {
+                username: {},
+              },
+            },
+            done
+          );
       });
 
-      it('should sanitize a nested object in a JSON body', function(done) {
+      it('should sanitize a nested object in a JSON body', function (done) {
         request(app)
           .post('/body')
           .send({
             username: {
               $gt: 'foo',
-              'dotted.data': 'some_data'
-            }
+              'dotted.data': 'some_data',
+            },
           })
           .set('Content-Type', 'application/json')
           .set('Accept', 'application/json')
-          .expect(200, {
-            body: {
-              username: {}
-            }
-          }, done);
+          .expect(
+            200,
+            {
+              body: {
+                username: {},
+              },
+            },
+            done
+          );
       });
 
-      it('should sanitize a nested object in a form url-encoded body', function(done) {
+      it('should sanitize a nested object in a form url-encoded body', function (done) {
         request(app)
           .post('/body')
           .send('username[$gt]=foo&username[dotted.data]=some_data')
           .set('Content-Type', 'application/x-www-form-urlencoded')
           .set('Accept', 'application/json')
-          .expect(200, {
-            body: {
-              username: {}
-            }
-          }, done);
+          .expect(
+            200,
+            {
+              body: {
+                username: {},
+              },
+            },
+            done
+          );
       });
     });
 
-    describe('Nested Object inside an Array', function() {
-      it('should sanitize a nested object in the query string', function(done) {
+    describe('Nested Object inside an Array', function () {
+      it('should sanitize a nested object in the query string', function (done) {
         request(app)
           .get('/query?username[0][$gt]=foo&username[0][dotted.data]=some_data')
           .set('Accept', 'application/json')
-          .expect(200, {
-            query: {
-              username: [{}]
-            }
-          }, done);
+          .expect(
+            200,
+            {
+              query: {
+                username: [{}],
+              },
+            },
+            done
+          );
       });
 
-      it('should sanitize a nested object in a JSON body', function(done) {
+      it('should sanitize a nested object in a JSON body', function (done) {
         request(app)
           .post('/body')
           .send({
-            username: [{
-              $gt: 'foo',
-              'dotted.data': 'some_data'
-            }]
+            username: [
+              {
+                $gt: 'foo',
+                'dotted.data': 'some_data',
+              },
+            ],
           })
           .set('Content-Type', 'application/json')
           .set('Accept', 'application/json')
-          .expect(200, {
-            body: {
-              username: [{}]
-            }
-          }, done);
+          .expect(
+            200,
+            {
+              body: {
+                username: [{}],
+              },
+            },
+            done
+          );
       });
 
-      it('should sanitize a nested object in a form url-encoded body', function(done) {
+      it('should sanitize a nested object in a form url-encoded body', function (done) {
         request(app)
           .post('/body')
           .send('username[0][$gt]=foo&username[0][dotted.data]=some_data')
           .set('Content-Type', 'application/x-www-form-urlencoded')
           .set('Accept', 'application/json')
-          .expect(200, {
-            body: {
-              username: [{}]
-            }
-          }, done);
+          .expect(
+            200,
+            {
+              body: {
+                username: [{}],
+              },
+            },
+            done
+          );
       });
     });
   });
 
-  describe('Preserve Data', function() {
+  describe('Preserve Data', function () {
     const app = express();
-    app.use(bodyParser.urlencoded({extended: true}));
+    app.use(bodyParser.urlencoded({ extended: true }));
     app.use(bodyParser.json());
-    app.use(sanitize({
-      replaceWith: '_'
-    }));
+    app.use(
+      sanitize({
+        replaceWith: '_',
+      })
+    );
 
-    app.post('/body', function(req, res){
+    app.post('/body', function (req, res) {
       res.status(200).json({
-        body: req.body
+        body: req.body,
       });
     });
 
-    app.post('/headers', function (req, res){
+    app.post('/headers', function (req, res) {
       res.status(200).json({
-        headers: req.headers
+        headers: req.headers,
       });
     });
 
-    app.get('/query', function(req, res){
+    app.get('/query', function (req, res) {
       res.status(200).json({
-        query: req.query
+        query: req.query,
       });
     });
 
-    describe('Top-level object', function() {
-      it('should sanitize the query string', function(done) {
+    describe('Top-level object', function () {
+      it('should sanitize the query string', function (done) {
         request(app)
           .get('/query?q=search&$where=malicious&dotted.data=some_data')
           .set('Accept', 'application/json')
-          .expect(200, {
-            query: {
-              q: 'search',
-              _where: 'malicious',
-              dotted_data: 'some_data'
-            }
-          }, done);
+          .expect(
+            200,
+            {
+              query: {
+                q: 'search',
+                _where: 'malicious',
+                dotted_data: 'some_data',
+              },
+            },
+            done
+          );
       });
 
-      it('should sanitize a JSON body', function(done) {
+      it('should sanitize a JSON body', function (done) {
         request(app)
           .post('/body')
           .send({
@@ -243,23 +287,27 @@ describe('Express Mongo Sanitize', function() {
             even: null,
             stop: undefined,
             $where: 'malicious',
-            'dotted.data': 'some_data'
+            'dotted.data': 'some_data',
           })
           .set('Content-Type', 'application/json')
           .set('Accept', 'application/json')
-          .expect(200, {
-            body: {
-              q: 'search',
-              is: true,
-              and: 1,
-              even: null,
-              _where: 'malicious',
-              dotted_data: 'some_data'
-            }
-          }, done);
+          .expect(
+            200,
+            {
+              body: {
+                q: 'search',
+                is: true,
+                and: 1,
+                even: null,
+                _where: 'malicious',
+                dotted_data: 'some_data',
+              },
+            },
+            done
+          );
       });
 
-      it('should sanitize HTTP headers', function(done) {
+      it('should sanitize HTTP headers', function (done) {
         request(app)
           .post('/headers')
           .set({
@@ -268,174 +316,214 @@ describe('Express Mongo Sanitize', function() {
             and: 1,
             even: null,
             $where: 'malicious',
-            'dotted.data': 'some_data'
+            'dotted.data': 'some_data',
           })
-          .expect(function(res) {
+          .expect(function (res) {
             expect(res.body.headers).to.include({
               q: 'search',
               is: 'true',
               and: '1',
               even: 'null',
               _where: 'malicious',
-              dotted_data: 'some_data'
-            })
+              dotted_data: 'some_data',
+            });
           })
           .end(done);
       });
 
-      it('should sanitize a form url-encoded body', function(done) {
+      it('should sanitize a form url-encoded body', function (done) {
         request(app)
           .post('/body')
           .send('q=search&$where=malicious&dotted.data=some_data')
           .set('Content-Type', 'application/x-www-form-urlencoded')
           .set('Accept', 'application/json')
-          .expect(200, {
-            body: {
-              q: 'search',
-              _where: 'malicious',
-              dotted_data: 'some_data'
-            }
-          }, done);
+          .expect(
+            200,
+            {
+              body: {
+                q: 'search',
+                _where: 'malicious',
+                dotted_data: 'some_data',
+              },
+            },
+            done
+          );
       });
     });
 
-    describe('Nested Object', function() {
-      it('should sanitize a nested object in the query string', function(done) {
+    describe('Nested Object', function () {
+      it('should sanitize a nested object in the query string', function (done) {
         request(app)
           .get('/query?username[$gt]=foo&username[dotted.data]=some_data')
           .set('Accept', 'application/json')
-          .expect(200, {
-            query: {
-              username: {
-                _gt: 'foo',
-                dotted_data: 'some_data'
-              }
-            }
-          }, done);
+          .expect(
+            200,
+            {
+              query: {
+                username: {
+                  _gt: 'foo',
+                  dotted_data: 'some_data',
+                },
+              },
+            },
+            done
+          );
       });
 
-      it('should sanitize a nested object in a JSON body', function(done) {
+      it('should sanitize a nested object in a JSON body', function (done) {
         request(app)
           .post('/body')
           .send({
             username: {
               $gt: 'foo',
-              'dotted.data': 'some_data'
-            }
+              'dotted.data': 'some_data',
+            },
           })
           .set('Content-Type', 'application/json')
           .set('Accept', 'application/json')
-          .expect(200, {
-            body: {
-              username: {
-                _gt: 'foo',
-                dotted_data: 'some_data'
-              }
-            }
-          }, done);
+          .expect(
+            200,
+            {
+              body: {
+                username: {
+                  _gt: 'foo',
+                  dotted_data: 'some_data',
+                },
+              },
+            },
+            done
+          );
       });
 
-      it('should sanitize a nested object in a form url-encoded body', function(done) {
+      it('should sanitize a nested object in a form url-encoded body', function (done) {
         request(app)
           .post('/body')
           .send('username[$gt]=foo&username[dotted.data]=some_data')
           .set('Content-Type', 'application/x-www-form-urlencoded')
           .set('Accept', 'application/json')
-          .expect(200, {
-            body: {
-              username: {
-                _gt: 'foo',
-                dotted_data: 'some_data'
-              }
-            }
-          }, done);
+          .expect(
+            200,
+            {
+              body: {
+                username: {
+                  _gt: 'foo',
+                  dotted_data: 'some_data',
+                },
+              },
+            },
+            done
+          );
       });
     });
 
-    describe('Nested Object inside an Array', function() {
-      it('should sanitize a nested object in the query string', function(done) {
+    describe('Nested Object inside an Array', function () {
+      it('should sanitize a nested object in the query string', function (done) {
         request(app)
           .get('/query?username[0][$gt]=foo&username[0][dotted.data]=some_data')
           .set('Accept', 'application/json')
-          .expect(200, {
-            query: {
-              username: [{
-                _gt: 'foo',
-                dotted_data: 'some_data'
-              }]
-            }
-          }, done);
+          .expect(
+            200,
+            {
+              query: {
+                username: [
+                  {
+                    _gt: 'foo',
+                    dotted_data: 'some_data',
+                  },
+                ],
+              },
+            },
+            done
+          );
       });
 
-      it('should sanitize a nested object in a JSON body', function(done) {
+      it('should sanitize a nested object in a JSON body', function (done) {
         request(app)
           .post('/body')
           .send({
-            username: [{
-              $gt: 'foo',
-              'dotted.data': 'some_data'
-            }]
+            username: [
+              {
+                $gt: 'foo',
+                'dotted.data': 'some_data',
+              },
+            ],
           })
           .set('Content-Type', 'application/json')
           .set('Accept', 'application/json')
-          .expect(200, {
-            body: {
-              username: [{
-                _gt: 'foo',
-                dotted_data: 'some_data'
-              }]
-            }
-          }, done);
+          .expect(
+            200,
+            {
+              body: {
+                username: [
+                  {
+                    _gt: 'foo',
+                    dotted_data: 'some_data',
+                  },
+                ],
+              },
+            },
+            done
+          );
       });
 
-      it('should sanitize a nested object in a form url-encoded body', function(done) {
+      it('should sanitize a nested object in a form url-encoded body', function (done) {
         request(app)
           .post('/body')
           .send('username[0][$gt]=foo&username[0][dotted.data]=some_data')
           .set('Content-Type', 'application/x-www-form-urlencoded')
           .set('Accept', 'application/json')
-          .expect(200, {
-            body: {
-              username: [{
-                _gt: 'foo',
-                dotted_data: 'some_data'
-              }]
-            }
-          }, done);
+          .expect(
+            200,
+            {
+              body: {
+                username: [
+                  {
+                    _gt: 'foo',
+                    dotted_data: 'some_data',
+                  },
+                ],
+              },
+            },
+            done
+          );
       });
     });
 
-    describe('Nested Object inside one with prohibited chars', function() {
-      it('should sanitize a nested object inside one with prohibited chars in a JSON body', function(done) {
+    describe('Nested Object inside one with prohibited chars', function () {
+      it('should sanitize a nested object inside one with prohibited chars in a JSON body', function (done) {
         request(app)
           .post('/body')
           .send({
             username: {
               $gt: 'foo',
               'dotted.data': {
-                'more.dotted.data': 'some_data'
-              }
-            }
+                'more.dotted.data': 'some_data',
+              },
+            },
           })
           .set('Content-Type', 'application/json')
           .set('Accept', 'application/json')
-          .expect(200, {
-            body: {
-              username: {
-                _gt: 'foo',
-                dotted_data: {
-                  'more_dotted_data': 'some_data'
-                }
-              }
-            }
-          }, done);
+          .expect(
+            200,
+            {
+              body: {
+                username: {
+                  _gt: 'foo',
+                  dotted_data: {
+                    more_dotted_data: 'some_data',
+                  },
+                },
+              },
+            },
+            done
+          );
       });
     });
 
-    describe('prototype pollution', function() {
+    describe('prototype pollution', function () {
       const createApp = (options) => {
         const app = express();
-        app.use(bodyParser.urlencoded({extended: true}));
+        app.use(bodyParser.urlencoded({ extended: true }));
         app.use(bodyParser.json());
         app.use(sanitize(options));
 
@@ -443,217 +531,1063 @@ describe('Express Mongo Sanitize', function() {
           // should not inject valued
           expect(req.body.injected).to.be.undefined;
           res.status(200).json({
-            body: req.body
+            body: req.body,
           });
         });
         return app;
-      }
+      };
       it('should not set __proto__ property', function (done) {
         const app = createApp({
-          replaceWith: "_"
+          replaceWith: '_',
         });
         request(app)
-            .post('/body')
-            .send({
-              // replace $ with _
-              $_proto__: {
-                injected: "injected value"
-              },
-              query: {
-                q: 'search'
-              }
-            })
-            .set('Content-Type', 'application/json')
-            .set('Accept', 'application/json')
-            .expect(200, {
+          .post('/body')
+          .send({
+            // replace $ with _
+            $_proto__: {
+              injected: 'injected value',
+            },
+            query: {
+              q: 'search',
+            },
+          })
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(
+            200,
+            {
               body: {
                 query: {
-                  q: 'search'
-                }
-              }
-            }, done);
+                  q: 'search',
+                },
+              },
+            },
+            done
+          );
       });
       it('should not set constructor property', function (done) {
         const app = createApp({
-          replaceWith: "c"
+          replaceWith: 'c',
         });
         request(app)
           .post('/body')
           .send({
             // replace $ with c
             $onstructor: {
-              injected: "injected value"
+              injected: 'injected value',
             },
             query: {
-              q: 'search'
-            }
+              q: 'search',
+            },
           })
           .set('Content-Type', 'application/json')
           .set('Accept', 'application/json')
-          .expect(200, {
-            body: {
-              query: {
-                q: 'search'
-              }
-            }
-          }, done);
+          .expect(
+            200,
+            {
+              body: {
+                query: {
+                  q: 'search',
+                },
+              },
+            },
+            done
+          );
       });
       it('should not set prototype property', function (done) {
         const app = createApp({
-          replaceWith: "p"
+          replaceWith: 'p',
         });
         request(app)
           .post('/body')
           .send({
             // replace $ with empty p
             $rototype: {
-              injected: "injected value"
+              injected: 'injected value',
             },
             query: {
-              q: 'search'
-            }
+              q: 'search',
+            },
           })
           .set('Content-Type', 'application/json')
           .set('Accept', 'application/json')
-          .expect(200, {
-            body: {
-              query: {
-                q: 'search'
-              }
-            }
-          }, done);
+          .expect(
+            200,
+            {
+              body: {
+                query: {
+                  q: 'search',
+                },
+              },
+            },
+            done
+          );
       });
     });
   });
 
-  describe('Preserve Data: prohibited characters', function() {
-    it('should not allow data to be replaced with a `$`', function(done) {
+  describe('Preserve Data: prohibited characters', function () {
+    it('should not allow data to be replaced with a `$`', function (done) {
       const app = express();
-      app.use(bodyParser.urlencoded({extended: true}));
-      app.use(sanitize({
-        replaceWith: '$'
-      }));
+      app.use(bodyParser.urlencoded({ extended: true }));
+      app.use(
+        sanitize({
+          replaceWith: '$',
+        })
+      );
 
-      app.get('/query', function(req, res){
+      app.get('/query', function (req, res) {
         res.status(200).json({
-          query: req.query
+          query: req.query,
         });
       });
-       request(app)
+      request(app)
         .get('/query?q=search&$where=malicious&dotted.data=some_data')
         .set('Accept', 'application/json')
-        .expect(200, {
-          query: {
-            q: 'search'
-          }
-        }, done);
+        .expect(
+          200,
+          {
+            query: {
+              q: 'search',
+            },
+          },
+          done
+        );
     });
 
-    it('should not allow data to be replaced with a `.`', function(done) {
+    it('should not allow data to be replaced with a `.`', function (done) {
       const app = express();
-      app.use(bodyParser.urlencoded({extended: true}));
-      app.use(sanitize({
-        replaceWith: '.'
-      }));
+      app.use(bodyParser.urlencoded({ extended: true }));
+      app.use(
+        sanitize({
+          replaceWith: '.',
+        })
+      );
 
-      app.get('/query', function(req, res){
+      app.get('/query', function (req, res) {
         res.status(200).json({
-          query: req.query
+          query: req.query,
         });
       });
-       request(app)
+      request(app)
         .get('/query?q=search&$where=malicious&dotted.data=some_data')
         .set('Accept', 'application/json')
-        .expect(200, {
-          query: {
-            q: 'search'
-          }
-        }, done);
+        .expect(
+          200,
+          {
+            query: {
+              q: 'search',
+            },
+          },
+          done
+        );
     });
   });
 
-  describe('Has Prohibited Keys', function() {
-    it('should return true if the object has a key beginning with a `$`', function() {
+  describe('Has Prohibited Keys', function () {
+    it('should return true if the object has a key beginning with a `$`', function () {
       const input = {
-        $prohibited: 'key'
+        $prohibited: 'key',
       };
       expect(sanitize.has(input)).to.be.true;
     });
 
-    it('should return true if the object has a key containing a `.`', function() {
+    it('should return true if the object has a key containing a `.`', function () {
       const input = {
-        'prohibited.key': 'value'
+        'prohibited.key': 'value',
       };
       expect(sanitize.has(input)).to.be.true;
     });
 
-    it('should return true if the object has a nested key beginning with a `$`', function() {
+    it('should return true if the object has a nested key beginning with a `$`', function () {
       const input = {
         nested: {
-          $prohibited: 'key'
-        }
+          $prohibited: 'key',
+        },
       };
       expect(sanitize.has(input)).to.be.true;
     });
 
-    it('should return true if the object has a nested key containing a `.`', function() {
+    it('should return true if the object has a nested key containing a `.`', function () {
       const input = {
         nested: {
-          'prohibited.key': 'value'
-        }
+          'prohibited.key': 'value',
+        },
       };
       expect(sanitize.has(input)).to.be.true;
     });
 
-    it('should return true if the array contains an object with a key beginning with a `$`', function() {
-      const input = [{
-        $prohibited: 'key'
-      }];
+    it('should return true if the array contains an object with a key beginning with a `$`', function () {
+      const input = [
+        {
+          $prohibited: 'key',
+        },
+      ];
       expect(sanitize.has(input)).to.be.true;
     });
 
-    it('should return true if the array contains an object with a key containing a `.`', function() {
-      const input = [{
-        'prohibited.key': 'value'
-      }];
+    it('should return true if the array contains an object with a key containing a `.`', function () {
+      const input = [
+        {
+          'prohibited.key': 'value',
+        },
+      ];
       expect(sanitize.has(input)).to.be.true;
     });
 
-    it('should return true if the payload contains a deeply nested object with a key beginning with a `$`', function() {
-      const input = [{
-        some: {
-          deeply: [{
-            nested: {
-              $prohibited: 'key'
-            }
-          }]
-        }
-      }];
+    it('should return true if the payload contains a deeply nested object with a key beginning with a `$`', function () {
+      const input = [
+        {
+          some: {
+            deeply: [
+              {
+                nested: {
+                  $prohibited: 'key',
+                },
+              },
+            ],
+          },
+        },
+      ];
       expect(sanitize.has(input)).to.be.true;
     });
 
-    it('should return true if the payload contains a deeply nested object with a key containing a `.`', function() {
-      const input = [{
-        some: {
-          deeply: [{
-            nested: {
-              'prohibited..key': 'key'
-            }
-          }]
-        }
-      }];
+    it('should return true if the payload contains a deeply nested object with a key containing a `.`', function () {
+      const input = [
+        {
+          some: {
+            deeply: [
+              {
+                nested: {
+                  'prohibited..key': 'key',
+                },
+              },
+            ],
+          },
+        },
+      ];
       expect(sanitize.has(input)).to.be.true;
     });
 
-    it('should return false if the payload doesn\'t contain any prohibited characters', function() {
+    it("should return false if the payload doesn't contain any prohibited characters", function () {
       const input = {
         some: {
-          nested: [{
-            data: 'panda'
-          }]
-        }
+          nested: [
+            {
+              data: 'panda',
+            },
+          ],
+        },
       };
       expect(sanitize.has(input)).to.be.false;
+    });
+  });
+});
+
+describe('Express Mongo Sanitize, Dots included', function () {
+  describe('Remove Data, Dots included', function () {
+    const app = express();
+    app.use(bodyParser.urlencoded({ extended: true }));
+    app.use(bodyParser.json());
+    app.use(sanitize({ allowDots: true }));
+
+    app.post('/body', function (req, res) {
+      res.status(200).json({
+        body: req.body,
+      });
+    });
+
+    app.post('/headers', function (req, res) {
+      res.status(200).json({
+        headers: req.headers,
+      });
+    });
+
+    app.get('/query', function (req, res) {
+      res.status(200).json({
+        query: req.query,
+      });
+    });
+
+    describe('Top-level object', function () {
+      it('should sanitize the query string', function (done) {
+        request(app)
+          .get('/query?q=search&$where=malicious&dotted.data=some_data')
+          .set('Accept', 'application/json')
+          .expect(
+            200,
+            {
+              query: {
+                q: 'search',
+                'dotted.data': 'some_data',
+              },
+            },
+            done
+          );
+      });
+
+      it('should sanitize a JSON body', function (done) {
+        request(app)
+          .post('/body')
+          .send({
+            q: 'search',
+            is: true,
+            and: 1,
+            even: null,
+            stop: undefined,
+            $where: 'malicious',
+            'dotted.data': 'some_data',
+          })
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(
+            200,
+            {
+              body: {
+                q: 'search',
+                is: true,
+                and: 1,
+                even: null,
+                'dotted.data': 'some_data',
+              },
+            },
+            done
+          );
+      });
+
+      it('should sanitize HTTP headers', function (done) {
+        request(app)
+          .post('/headers')
+          .set({
+            q: 'search',
+            is: true,
+            and: 1,
+            even: null,
+            $where: 'malicious',
+            'dotted.data': 'some_data',
+          })
+          .expect(200)
+          .expect(function (res) {
+            expect(res.body.headers).to.include({
+              q: 'search',
+              is: 'true',
+              and: '1',
+              even: 'null',
+              'dotted.data': 'some_data', //! Maybe not allow it in headers
+            });
+          })
+          .end(done);
+      });
+
+      it('should sanitize a form url-encoded body', function (done) {
+        request(app)
+          .post('/body')
+          .send('q=search&$where=malicious&dotted.data=some_data')
+          .set('Content-Type', 'application/x-www-form-urlencoded')
+          .set('Accept', 'application/json')
+          .expect(
+            200,
+            {
+              body: {
+                q: 'search',
+                'dotted.data': 'some_data',
+              },
+            },
+            done
+          );
+      });
+    });
+
+    describe('Nested Object', function () {
+      it('should sanitize a nested object in the query string', function (done) {
+        request(app)
+          .get('/query?username[$gt]=foo&username[dotted.data]=some_data')
+          .set('Accept', 'application/json')
+          .expect(
+            200,
+            {
+              query: {
+                username: {
+                  'dotted.data': 'some_data',
+                },
+              },
+            },
+            done
+          );
+      });
+
+      it('should sanitize a nested object in a JSON body', function (done) {
+        request(app)
+          .post('/body')
+          .send({
+            username: {
+              $gt: 'foo',
+              'dotted.data': 'some_data',
+            },
+          })
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(
+            200,
+            {
+              body: {
+                username: {
+                  'dotted.data': 'some_data',
+                },
+              },
+            },
+            done
+          );
+      });
+
+      it('should sanitize a nested object in a form url-encoded body', function (done) {
+        request(app)
+          .post('/body')
+          .send('username[$gt]=foo&username[dotted.data]=some_data')
+          .set('Content-Type', 'application/x-www-form-urlencoded')
+          .set('Accept', 'application/json')
+          .expect(
+            200,
+            {
+              body: {
+                username: {
+                  'dotted.data': 'some_data',
+                },
+              },
+            },
+            done
+          );
+      });
+    });
+
+    describe('Nested Object inside an Array', function () {
+      it('should sanitize a nested object in the query string', function (done) {
+        request(app)
+          .get('/query?username[0][$gt]=foo&username[0][dotted.data]=some_data')
+          .set('Accept', 'application/json')
+          .expect(
+            200,
+            {
+              query: {
+                username: [
+                  {
+                    'dotted.data': 'some_data',
+                  },
+                ],
+              },
+            },
+            done
+          );
+      });
+
+      it('should sanitize a nested object in a JSON body', function (done) {
+        request(app)
+          .post('/body')
+          .send({
+            username: [
+              {
+                $gt: 'foo',
+                'dotted.data': 'some_data',
+              },
+            ],
+          })
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(
+            200,
+            {
+              body: {
+                username: [
+                  {
+                    'dotted.data': 'some_data',
+                  },
+                ],
+              },
+            },
+            done
+          );
+      });
+
+      it('should sanitize a nested object in a form url-encoded body', function (done) {
+        request(app)
+          .post('/body')
+          .send('username[0][$gt]=foo&username[0][dotted.data]=some_data')
+          .set('Content-Type', 'application/x-www-form-urlencoded')
+          .set('Accept', 'application/json')
+          .expect(
+            200,
+            {
+              body: {
+                username: [
+                  {
+                    'dotted.data': 'some_data',
+                  },
+                ],
+              },
+            },
+            done
+          );
+      });
+    });
+  });
+
+  describe('Preserve Data, dots included', function () {
+    const app = express();
+    app.use(bodyParser.urlencoded({ extended: true }));
+    app.use(bodyParser.json());
+    app.use(
+      sanitize({
+        replaceWith: '_',
+        allowDots: true,
+      })
+    );
+
+    app.post('/body', function (req, res) {
+      res.status(200).json({
+        body: req.body,
+      });
+    });
+
+    app.post('/headers', function (req, res) {
+      res.status(200).json({
+        headers: req.headers,
+      });
+    });
+
+    app.get('/query', function (req, res) {
+      res.status(200).json({
+        query: req.query,
+      });
+    });
+
+    describe('Top-level object', function () {
+      it('should sanitize the query string', function (done) {
+        request(app)
+          .get('/query?q=search&$where=malicious&dotted.data=some_data')
+          .set('Accept', 'application/json')
+          .expect(
+            200,
+            {
+              query: {
+                q: 'search',
+                _where: 'malicious',
+                'dotted.data': 'some_data',
+              },
+            },
+            done
+          );
+      });
+
+      it('should sanitize a JSON body', function (done) {
+        request(app)
+          .post('/body')
+          .send({
+            q: 'search',
+            is: true,
+            and: 1,
+            even: null,
+            stop: undefined,
+            $where: 'malicious',
+            'dotted.data': 'some_data',
+          })
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(
+            200,
+            {
+              body: {
+                q: 'search',
+                is: true,
+                and: 1,
+                even: null,
+                _where: 'malicious',
+                'dotted.data': 'some_data',
+              },
+            },
+            done
+          );
+      });
+
+      it('should sanitize HTTP headers', function (done) {
+        request(app)
+          .post('/headers')
+          .set({
+            q: 'search',
+            is: true,
+            and: 1,
+            even: null,
+            $where: 'malicious',
+            'dotted.data': 'some_data',
+          })
+          .expect(function (res) {
+            expect(res.body.headers).to.include({
+              q: 'search',
+              is: 'true',
+              and: '1',
+              even: 'null',
+              _where: 'malicious',
+              'dotted.data': 'some_data',
+            });
+          })
+          .end(done);
+      });
+
+      it('should sanitize a form url-encoded body', function (done) {
+        request(app)
+          .post('/body')
+          .send('q=search&$where=malicious&dotted.data=some_data')
+          .set('Content-Type', 'application/x-www-form-urlencoded')
+          .set('Accept', 'application/json')
+          .expect(
+            200,
+            {
+              body: {
+                q: 'search',
+                _where: 'malicious',
+                'dotted.data': 'some_data',
+              },
+            },
+            done
+          );
+      });
+    });
+
+    describe('Nested Object', function () {
+      it('should sanitize a nested object in the query string', function (done) {
+        request(app)
+          .get('/query?username[$gt]=foo&username[dotted.data]=some_data')
+          .set('Accept', 'application/json')
+          .expect(
+            200,
+            {
+              query: {
+                username: {
+                  _gt: 'foo',
+                  'dotted.data': 'some_data',
+                },
+              },
+            },
+            done
+          );
+      });
+
+      it('should sanitize a nested object in a JSON body', function (done) {
+        request(app)
+          .post('/body')
+          .send({
+            username: {
+              $gt: 'foo',
+              'dotted.data': 'some_data',
+            },
+          })
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(
+            200,
+            {
+              body: {
+                username: {
+                  _gt: 'foo',
+                  'dotted.data': 'some_data',
+                },
+              },
+            },
+            done
+          );
+      });
+
+      it('should sanitize a nested object in a form url-encoded body', function (done) {
+        request(app)
+          .post('/body')
+          .send('username[$gt]=foo&username[dotted.data]=some_data')
+          .set('Content-Type', 'application/x-www-form-urlencoded')
+          .set('Accept', 'application/json')
+          .expect(
+            200,
+            {
+              body: {
+                username: {
+                  _gt: 'foo',
+                  'dotted.data': 'some_data',
+                },
+              },
+            },
+            done
+          );
+      });
+    });
+
+    describe('Nested Object inside an Array', function () {
+      it('should sanitize a nested object in the query string', function (done) {
+        request(app)
+          .get('/query?username[0][$gt]=foo&username[0][dotted.data]=some_data')
+          .set('Accept', 'application/json')
+          .expect(
+            200,
+            {
+              query: {
+                username: [
+                  {
+                    _gt: 'foo',
+                    'dotted.data': 'some_data',
+                  },
+                ],
+              },
+            },
+            done
+          );
+      });
+
+      it('should sanitize a nested object in a JSON body', function (done) {
+        request(app)
+          .post('/body')
+          .send({
+            username: [
+              {
+                $gt: 'foo',
+                'dotted.data': 'some_data',
+              },
+            ],
+          })
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(
+            200,
+            {
+              body: {
+                username: [
+                  {
+                    _gt: 'foo',
+                    'dotted.data': 'some_data',
+                  },
+                ],
+              },
+            },
+            done
+          );
+      });
+
+      it('should sanitize a nested object in a form url-encoded body', function (done) {
+        request(app)
+          .post('/body')
+          .send('username[0][$gt]=foo&username[0][dotted.data]=some_data')
+          .set('Content-Type', 'application/x-www-form-urlencoded')
+          .set('Accept', 'application/json')
+          .expect(
+            200,
+            {
+              body: {
+                username: [
+                  {
+                    _gt: 'foo',
+                    'dotted.data': 'some_data',
+                  },
+                ],
+              },
+            },
+            done
+          );
+      });
+    });
+
+    describe('Nested Object inside one with prohibited chars', function () {
+      it('should sanitize a nested object inside one with prohibited chars in a JSON body', function (done) {
+        request(app)
+          .post('/body')
+          .send({
+            username: {
+              $gt: 'foo',
+              'dotted.data': {
+                'more.dotted.data': 'some_data',
+              },
+            },
+          })
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(
+            200,
+            {
+              body: {
+                username: {
+                  _gt: 'foo',
+                  'dotted.data': {
+                    'more.dotted.data': 'some_data',
+                  },
+                },
+              },
+            },
+            done
+          );
+      });
+    });
+
+    describe('prototype pollution', function () {
+      const createApp = (options) => {
+        const app = express();
+        app.use(bodyParser.urlencoded({ extended: true }));
+        app.use(bodyParser.json());
+        app.use(sanitize(options));
+
+        app.post('/body', function (req, res) {
+          // should not inject valued
+          expect(req.body.injected).to.be.undefined;
+          res.status(200).json({
+            body: req.body,
+          });
+        });
+        return app;
+      };
+      it('should not set __proto__ property', function (done) {
+        const app = createApp({
+          replaceWith: '_',
+          allowDots: true,
+        });
+        request(app)
+          .post('/body')
+          .send({
+            // replace $ with _
+            $_proto__: {
+              injected: 'injected value',
+            },
+            query: {
+              q: 'search',
+            },
+          })
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(
+            200,
+            {
+              body: {
+                query: {
+                  q: 'search',
+                },
+              },
+            },
+            done
+          );
+      });
+      it('should not set constructor property', function (done) {
+        const app = createApp({
+          replaceWith: 'c',
+          allowDots: true,
+        });
+        request(app)
+          .post('/body')
+          .send({
+            // replace $ with c
+            $onstructor: {
+              injected: 'injected value',
+            },
+            query: {
+              q: 'search',
+            },
+          })
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(
+            200,
+            {
+              body: {
+                query: {
+                  q: 'search',
+                },
+              },
+            },
+            done
+          );
+      });
+      it('should not set prototype property', function (done) {
+        const app = createApp({
+          replaceWith: 'p',
+          allowDots: true,
+        });
+        request(app)
+          .post('/body')
+          .send({
+            // replace $ with empty p
+            $rototype: {
+              injected: 'injected value',
+            },
+            query: {
+              q: 'search',
+            },
+          })
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(
+            200,
+            {
+              body: {
+                query: {
+                  q: 'search',
+                },
+              },
+            },
+            done
+          );
+      });
+    });
+  });
+
+  describe('Preserve Data: prohibited characters (dots included)', function () {
+    it('should not allow data to be replaced with a `$`', function (done) {
+      const app = express();
+      app.use(bodyParser.urlencoded({ extended: true }));
+      app.use(
+        sanitize({
+          replaceWith: '$',
+          allowDots: true,
+        })
+      );
+
+      app.get('/query', function (req, res) {
+        res.status(200).json({
+          query: req.query,
+        });
+      });
+      request(app)
+        .get('/query?q=search&$where=malicious&dotted.data=some_data')
+        .set('Accept', 'application/json')
+        .expect(
+          200,
+          {
+            query: {
+              q: 'search',
+              'dotted.data': 'some_data',
+            },
+          },
+          done
+        );
+    });
+
+    it('it should not allow data to be replaced with a `.`, even if options.allowDots=true', function (done) {
+      const app = express();
+      app.use(bodyParser.urlencoded({ extended: true }));
+      app.use(
+        sanitize({
+          replaceWith: '.',
+          allowDots: true,
+        })
+      );
+
+      app.get('/query', function (req, res) {
+        res.status(200).json({
+          query: req.query,
+        });
+      });
+      request(app)
+        .get('/query?q=search&$where=malicious&dotted.data=some_data')
+        .set('Accept', 'application/json')
+        .expect(
+          200,
+          {
+            query: {
+              q: 'search',
+              'dotted.data': 'some_data',
+            },
+          },
+          done
+        );
+    });
+  });
+
+  describe('Has Prohibited Keys, with allowDots=true', function () {
+    it('should return true if the object has a key beginning with a `$`', function () {
+      const input = {
+        $prohibited: 'key',
+      };
+      expect(sanitize.has(input, true)).to.be.true;
+    });
+
+    it('should return true if the object has a key containing a `.`', function () {
+      const input = {
+        'prohibited.key': 'value',
+      };
+      expect(sanitize.has(input, true)).to.be.true;
+    });
+
+    it('should return true if the object has a nested key beginning with a `$`', function () {
+      const input = {
+        nested: {
+          $prohibited: 'key',
+        },
+      };
+      expect(sanitize.has(input, true)).to.be.true;
+    });
+
+    it('should return true if the object has a nested key containing a `.`', function () {
+      const input = {
+        nested: {
+          'prohibited.key': 'value',
+        },
+      };
+      expect(sanitize.has(input, true)).to.be.true;
+    });
+
+    it('should return true if the array contains an object with a key beginning with a `$`', function () {
+      const input = [
+        {
+          $prohibited: 'key',
+        },
+      ];
+      expect(sanitize.has(input, true)).to.be.true;
+    });
+
+    it('should return true if the array contains an object with a key containing a `.`', function () {
+      const input = [
+        {
+          'prohibited.key': 'value',
+        },
+      ];
+      expect(sanitize.has(input, true)).to.be.true;
+    });
+
+    it('should return true if the payload contains a deeply nested object with a key beginning with a `$`', function () {
+      const input = [
+        {
+          some: {
+            deeply: [
+              {
+                nested: {
+                  $prohibited: 'key',
+                },
+              },
+            ],
+          },
+        },
+      ];
+      expect(sanitize.has(input, true)).to.be.true;
+    });
+
+    it('should return true if the payload contains a deeply nested object with a key containing a `.`', function () {
+      const input = [
+        {
+          some: {
+            deeply: [
+              {
+                nested: {
+                  'prohibited..key': 'key',
+                },
+              },
+            ],
+          },
+        },
+      ];
+      expect(sanitize.has(input, true)).to.be.true;
+    });
+
+    it("should return false if the payload doesn't contain any prohibited characters", function () {
+      const input = {
+        some: {
+          nested: [
+            {
+              data: 'panda',
+            },
+          ],
+        },
+      };
+      expect(sanitize.has(input, true)).to.be.false;
     });
   });
 });


### PR DESCRIPTION
Adding new option/feature, options.allowDots that is used for skipping the sanitization of data that has .(dot). This can be useful for nested document quering for mongoDb: https://docs.mongodb.com/manual/tutorial/query-embedded-documents/

Creating new tests that include the new option

Updating the documentation (README.md) file for the new option

Adressing issue: https://github.com/fiznool/express-mongo-sanitize/issues/36