### PR TITLE
Remove the deprecated bodyParser docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,12 @@ Add as a piece of express middleware, before defining your routes.
 
 ```js
 const express = require('express');
-const bodyParser = require('body-parser');
 const mongoSanitize = require('express-mongo-sanitize');
 
 const app = express();
 
-app.use(bodyParser.urlencoded({ extended: true }));
-app.use(bodyParser.json());
+app.use(express.urlencoded({ extended: true }));
+app.use(express.json());
 
 // To remove data, use:
 app.use(mongoSanitize());


### PR DESCRIPTION
bodyParser is now part of express and is deprecated to be used separately

<img width="616" alt="Screen Shot 2564-05-17 at 12 41 49" src="https://user-images.githubusercontent.com/693487/118437675-41b87e80-b70d-11eb-8ee7-4579a4dc870d.png">
