### PR TITLE
Fix compatibility with Express 5.x.x read-only query object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "express-mongo-sanitize",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "express-mongo-sanitize",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/express": "^4.17.13",


### PR DESCRIPTION
Description:

This pull request addresses the compatibility issue between this module and Express 5.x.x, specifically regarding the read-only nature of `req.query` in the newer Express version.